### PR TITLE
Updated to work with Factorio 2.0

### DIFF
--- a/info.json
+++ b/info.json
@@ -4,7 +4,7 @@
   "title": "Recipe Logistic Request",
   "author": "Atria",
   "contact": "tomas.chmelik2@gmail.com",
-  "factorio_version": "1.1",
-  "dependencies": ["base >= 1.1"],
+  "factorio_version": "2.0",
+  "dependencies": ["base >= 2.0"],
   "description": "Mod which allows you to increase/decrease your personal logistic requests by clicking on recipes. Supports either requesting recipe result or its ingredients."
 }


### PR DESCRIPTION
This is mostly a POC, there are some changes in Factorio 2 to how logistic requests work, so I had to make some decisions about behaviour, rather than just porting it across as it was. The key difference is that there are now logistic sections which can belong to groups. I made the choice to use a named group, and if it does not exist for the player, then create it (wiping old logistic requests if they exist). It works well enough for me locally, but hasn't been extensively tested.